### PR TITLE
Implement lifecycle and connection events and entry points

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ repositories {
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.layered {
-		mappings "net.ornithemc:feather:${project.minecraft_version}+build.${project.feather_build}:v2"
-	}
+	mappings "net.ornithemc:feather:${project.minecraft_version}+build.${project.feather_build}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+	ploceus.dependOsl(project.osl_version)
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ archives_base_name = ornithe-carpet
 minecraft_version = 1.13.2
 feather_build = 18
 loader_version = 0.14.22
+osl_version = 0.9.0

--- a/src/main/java/com/kahzerx/carpet/CarpetServer.java
+++ b/src/main/java/com/kahzerx/carpet/CarpetServer.java
@@ -4,6 +4,9 @@ import com.kahzerx.carpet.api.settings.SettingsManager;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.source.CommandSourceStack;
+import net.minecraft.server.entity.living.player.ServerPlayerEntity;
+import net.ornithemc.osl.lifecycle.api.server.MinecraftServerEvents;
+import net.ornithemc.osl.networking.api.server.ServerConnectionEvents;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,10 +15,58 @@ public class CarpetServer {
 	public static MinecraftServer minecraftServer;
 	public static SettingsManager settingsManager;
 	public static final List<CarpetExtension> extensions = new ArrayList<>();
+
 	public static void onGameStarted() {
+		MinecraftServerEvents.START.register(server -> {
+			CarpetServer.minecraftServer = server;
+		});
+		MinecraftServerEvents.LOAD_WORLD.register(server -> {
+			CarpetServer.onServerLoaded();
+		});
+		MinecraftServerEvents.READY_WORLD.register(server -> {
+			CarpetServer.onServerLoadedWorlds();
+		});
+		MinecraftServerEvents.TICK_START.register(server -> {
+			CarpetServer.onServerTick();
+		});
+		MinecraftServerEvents.STOP.register(server -> {
+			CarpetServer.onServerClosed();
+			CarpetServer.minecraftServer = null;
+		});
+		ServerConnectionEvents.LOGIN.register((server, player) -> {
+			CarpetServer.onPlayerLoggedIn(player);
+		});
+		ServerConnectionEvents.DISCONNECT.register((server, player) -> {
+			CarpetServer.onPlayerLoggedOut(player);
+		});
+
 		settingsManager = new SettingsManager(CarpetSettings.carpetVersion, "carpet", "Ornithe Carpet");
 		settingsManager.parseSettingsClass(CarpetSettings.class);
 		extensions.forEach(CarpetExtension::onGameStarted);
+	}
+
+	public static void onServerLoaded() {
+		extensions.forEach(extension -> extension.onServerLoaded(minecraftServer));
+	}
+
+	public static void onServerLoadedWorlds() {
+		extensions.forEach(extension -> extension.onServerLoadedWorlds(minecraftServer));
+	}
+
+	public static void onServerTick() {
+		extensions.forEach(extension -> extension.onTick(minecraftServer));
+	}
+
+	public static void onServerClosed() {
+		extensions.forEach(extension -> extension.onServerClosed(minecraftServer));
+	}
+
+	public static void onPlayerLoggedIn(ServerPlayerEntity player) {
+		extensions.forEach(extension -> extension.onPlayerLoggedIn(player));
+	}
+
+	public static void onPlayerLoggedOut(ServerPlayerEntity player) {
+		extensions.forEach(extension -> extension.onPlayerLoggedOut(player));
 	}
 
 	public static void registerCarpetCommands(CommandDispatcher<CommandSourceStack> dispatcher) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,18 +15,18 @@
 	"icon": "assets/ornithe_carpet/icon.png",
 	"environment": "*",
 	"entrypoints": {
-      "client": [
-        "com.kahzerx.carpet.CarpetServer::onGameStarted"
-      ],
-      "server": [
-        "com.kahzerx.carpet.CarpetServer::onGameStarted"
-      ]
-    },
+		"init": [
+			"com.kahzerx.carpet.CarpetServer::onGameStarted"
+		]
+	},
 	"mixins": [
-      "ornithe_carpet.mixins.json"
+		"ornithe_carpet.mixins.json"
 	],
 	"depends": {
 		"fabricloader": ">=0.14.22",
-		"minecraft": "1.13.2"
+		"minecraft": "1.13.2",
+		"osl-entrypoints": ">=0.4.0",
+		"osl-lifecycle-events": ">=0.5.0",
+		"osl-networking": ">=0.5.0"
 	}
 }


### PR DESCRIPTION
PR adds OSL dependency for lifecycle events, connection events, and entrypoints. The lifecycle and connection events are to my knowledge be the same as in modern carpet, so server loaded event at the start of `loadWorld`, server loaded worlds event at the end of `loadWorld`, server tick event at the beginning of `tick`. As for entrypoints, I opted to use OSL's entrypoints for the sake of compatibility with Quilt Loader. While Quilt Loader does still support Fabric's entrypoints, they are deprecated and should not be used. For the connection events, I opted not to invoke the player login event at play ready, since that is only fired when the client also has OSL installed.